### PR TITLE
BUGfix

### DIFF
--- a/scripts/tmux_world_clock.sh
+++ b/scripts/tmux_world_clock.sh
@@ -68,6 +68,11 @@ print_time_info() {
   if [ ! -z $last_timezone ]; then
     echo -n "$(_get_date_time "$last_timezone" "$bgcolor" "$fgcolor" "$fmt") "
   fi
+
+  #-- this echo (outputs <lf>) is mandatory
+  #   if not given, all plugins are run all the time with no scheduling
+  #   not sure if this is desired behavior or a bug
+  echo ""
 }
 
 print_time_info


### PR DESCRIPTION
Hi Alex,

I found that my change added a change (no \n at the end of the output) that seems to trigger a bug in the plugin system.

Basically, this ran all the plugins as soon as it could all the time and did not wait for the update cycle to complete. I have no idea where this bug is homed, but echoing a \n fixes the symptom.